### PR TITLE
feat(ai-client): expose loggers and set nullLogger as default

### DIFF
--- a/packages/ai-client/README.md
+++ b/packages/ai-client/README.md
@@ -289,6 +289,77 @@ const nextResponse = await client.ask({
 });
 ```
 
+## Logging
+
+The client supports custom logging through the `logger` option. By default, the client uses a silent logger that produces no output.
+
+### Available Loggers
+
+```typescript
+import { buildClient, consoleLogger, nullLogger } from "@platformatic/ai-client";
+
+// Silent logger (default) - no logging output
+const client = buildClient({
+  url: "http://127.0.0.1:3042",
+  logger: nullLogger, // This is the default
+});
+
+// Console logger - logs to console
+const client = buildClient({
+  url: "http://127.0.0.1:3042",
+  logger: consoleLogger,
+});
+```
+
+### Custom Logger
+
+You can provide your own logger implementation:
+
+```typescript
+import { buildClient } from "@platformatic/ai-client";
+
+const customLogger = {
+  debug: (message: string, data?: any) => {
+    // Custom debug logging
+    console.debug(`[DEBUG] ${message}`, data);
+  },
+  info: (message: string, data?: any) => {
+    // Custom info logging
+    console.info(`[INFO] ${message}`, data);
+  },
+  warn: (message: string, data?: any) => {
+    // Custom warning logging
+    console.warn(`[WARN] ${message}`, data);
+  },
+  error: (message: string, data?: any) => {
+    // Custom error logging
+    console.error(`[ERROR] ${message}`, data);
+  },
+};
+
+const client = buildClient({
+  url: "http://127.0.0.1:3042",
+  logger: customLogger,
+});
+```
+
+### Logger Interface
+
+```typescript
+interface Logger {
+  debug(message: string, data?: any): void;
+  info(message: string, data?: any): void;
+  warn(message: string, data?: any): void;
+  error(message: string, data?: any): void;
+}
+```
+
+The client will log various events including:
+- Request details (debug level)
+- Successful responses (info level) 
+- Request timeouts (warn level)
+- Request errors (error level)
+
 ## Examples
 
 The package includes working examples:
@@ -338,7 +409,7 @@ Creates a new AI client instance.
 - `url` (string): The AI service URL
 - `headers` (object, optional): HTTP headers to include with requests
 - `timeout` (number, optional): Request timeout in milliseconds (default: 60000)
-- `logger` (Logger, optional): Logger instance (uses console log if not provided)
+- `logger` (Logger, optional): Logger instance (default: silent logger - no logging)
 - `promptPath` (string, optional): Custom path for direct requests (default: `/api/v1/prompt`)
 - `streamPath` (string, optional): Custom path for streaming requests (default: `/api/v1/stream`)
 

--- a/packages/ai-client/src/client.ts
+++ b/packages/ai-client/src/client.ts
@@ -1,5 +1,5 @@
 import type { AskOptions, ClientOptions, StreamMessage, AskResponse, Logger, AskResponseStream, AskResponseContent } from './types.ts'
-import { consoleLogger } from './console-logger.ts'
+import { nullLogger } from './console-logger.ts'
 
 const DEFAULT_PROMPT_PATH = '/api/v1/prompt'
 const DEFAULT_STREAM_PATH = '/api/v1/stream'
@@ -20,7 +20,7 @@ export class Client {
       ...options.headers
     }
     this.timeout = options.timeout ?? DEFAULT_TIMEOUT
-    this.logger = options.logger ?? consoleLogger
+    this.logger = options.logger ?? nullLogger
     this.promptPath = options.promptPath ?? DEFAULT_PROMPT_PATH
     this.streamPath = options.streamPath ?? DEFAULT_STREAM_PATH
   }

--- a/packages/ai-client/src/console-logger.ts
+++ b/packages/ai-client/src/console-logger.ts
@@ -30,3 +30,10 @@ export const consoleLogger: Logger = {
     }
   }
 }
+
+export const nullLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {}
+}

--- a/packages/ai-client/src/index.ts
+++ b/packages/ai-client/src/index.ts
@@ -5,6 +5,8 @@ export function buildClient (options: ClientOptions): Client {
   return new Client(options)
 }
 
+export { consoleLogger, nullLogger } from './console-logger.ts'
+
 export type {
   ClientOptions,
   AskOptions,


### PR DESCRIPTION
## Summary
- Export `consoleLogger` and `nullLogger` from main package for user access
- Create `nullLogger` implementation for silent logging (no output)  
- Set `nullLogger` as default instead of `consoleLogger` to reduce noise
- Add comprehensive logging documentation to README with examples

## Test plan
- [x] All existing ai-client tests pass (42/42)
- [x] New loggers are properly exported and accessible
- [x] Default behavior changed from console logging to silent logging
- [x] Documentation updated with usage examples and interface details

🤖 Generated with [Claude Code](https://claude.ai/code)